### PR TITLE
Changes to accommodate ordered factors

### DIFF
--- a/R/omixerCorr.R
+++ b/R/omixerCorr.R
@@ -41,15 +41,15 @@
 omixerCorr <- function(x, y) {
 
     ## Convert variables to numeric
-    if(class(x) %in% c("character")) x <- as.numeric(as_factor(x))
-    if(class(y) %in% c("character")) y <- as.numeric(as_factor(y))
-    if(class(x) %in% c("Date", "factor")) x <- as.numeric(x)
-    if(class(y) %in% c("Date", "factor")) y <- as.numeric(y)
+    if(any(class(x) %in% c("character"))) x <- as.numeric(as_factor(x))
+    if(any(class(y) %in% c("character"))) y <- as.numeric(as_factor(y))
+    if(any(class(x) %in% c("Date", "factor", "ordered"))) x <- as.numeric(x)
+    if(any(class(y) %in% c("Date", "factor", "ordered"))) y <- as.numeric(y)
 
     ## Save correlation estimates and p values
     if(length(unique(x)) < 5 & length(unique(y)) < 5) {
         ## Two categorical variables
-        cvStat <- chisq.test(x, y, correct=FALSE)$statistics
+        cvStat <- chisq.test(x, y, correct=FALSE)$statistic
         if(is.null(cvStat)) cvStat <- 0
         cv <- sqrt(cvStat/(length(x)*min(length(unique(x)),
             length(unique(y)))-1))


### PR DESCRIPTION
When dealing with ordered factors, the class function outputs '"ordered" "factor"', meaning that all of the if statements on lines 44-47 are FALSE and that a non-numeric variable is passed on for the correlation analysis, resulting in an error. The changes here allow the omixerCorr function to handle ordered factors without resulting in an error. Additionally, since the output of chisq.test doesn't have a "statistics" component, the cv variable will always end up being 0. The minor change on line 52 results in the statistic being correctly stored.